### PR TITLE
fixed timing bugs + smoother progress bar

### DIFF
--- a/lib/timer_constants.dart
+++ b/lib/timer_constants.dart
@@ -1,2 +1,3 @@
-const defaultRepDuration = Duration(seconds: 60);
+const defaultRepDuration = Duration(seconds: 3);
 const defaultSetCount = 1;
+const tickIncrement = Duration(milliseconds: 10);

--- a/lib/widgets/config_panel.dart
+++ b/lib/widgets/config_panel.dart
@@ -4,6 +4,7 @@ import 'package:timr/widgets/start_button.dart';
 import 'package:timr/models.dart';
 import 'package:timr/widgets/pause_button.dart';
 import 'package:timr/widgets/rep_time_picker.dart';
+import 'package:timr/widgets/set_picker.dart';
 
 class ConfigPanel extends StatelessWidget {
   TimerSettings timerSettings;
@@ -28,9 +29,14 @@ class ConfigPanel extends StatelessWidget {
       ),
       RepTimePicker(
         context: context,
-        repDuration: timerSettings.repDuration,
+        repDuration: timerSettings.getRepDuration(),
         setRepDuration: (Duration newDuration) => timerSettings.setRepDuration(newDuration)
       ),
+      SetPicker(
+        context: context,
+        setCount: timerSettings.getSetCount(),
+        setSetCount: (int value) => timerSettings.setSetCount(value)
+      )
     ]
   );
 } 

--- a/lib/widgets/set_picker.dart
+++ b/lib/widgets/set_picker.dart
@@ -1,22 +1,21 @@
 import 'package:flutter/cupertino.dart';
-import 'package:timr/models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
-
-class RepTimePicker extends StatelessWidget {
-  final void Function(Duration) setRepDuration;
-  Duration repDuration;
+class SetPicker extends StatelessWidget {
+  final void Function(int) setSetCount;
+  int setCount;
   static const text = 'Pause';
   static const color = Colors.black;
   static const backgroundColor = Colors.white;
   BuildContext context;
 
   //This is the constructor
-  RepTimePicker({
+  SetPicker({
     super.key,
     required this.context,
-    required this.repDuration,
-    required this.setRepDuration
+    required this.setCount,
+    required this.setSetCount,
   });
 
   void _showDialog(Widget child) {
@@ -25,67 +24,61 @@ class RepTimePicker extends StatelessWidget {
       builder: (BuildContext context) => Container(
         height: 216,
         padding: const EdgeInsets.only(top: 6.0),
-        // The bottom margin is provided to align the popup above the system
-        // navigation bar.
         margin: EdgeInsets.only(
           bottom: MediaQuery.of(context).viewInsets.bottom,
         ),
-        // Provide a background color for the popup.
         color: CupertinoColors.systemBackground.resolveFrom(context),
-        // Use a SafeArea widget to avoid system overlaps.
         child: SafeArea(
           top: false,
           child: child,
-        ),
+        )
       ),
     );
   }
 
-  @override 
+  @override
   Widget build(BuildContext context) => Center(
     child: Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        _TimerPickerItem(
+        _SetPickerItem(
           children: <Widget>[
             const Text(
-              'Timer',
+              'Number of sets',
               style: TextStyle(
                 fontSize: 22.0,
                 color: Colors.white
-              )),
+              )
+            ),
             CupertinoButton(
-              // Display a CupertinoTimerPicker with hour/minute mode.
               onPressed: () => _showDialog(
-                CupertinoTimerPicker(
-                  mode: CupertinoTimerPickerMode.ms,
-                  initialTimerDuration: repDuration,
-                  // This is called when the user changes the timer's
-                  // duration.
-                  onTimerDurationChanged: (Duration newDuration) => setRepDuration(newDuration)
-                ),
+                CupertinoTextField(
+                  keyboardType: TextInputType.number,
+                  inputFormatters: <TextInputFormatter>[
+                    FilteringTextInputFormatter.digitsOnly
+                  ],
+                  onSubmitted: (String value) {
+                    setSetCount(int.parse(value));
+                  },
+                )
               ),
-              // In this example, the timer's value is formatted manually.
-              // You can use the intl package to format the value based on
-              // the user's locale settings.
               child: Text(
-                '$repDuration',
+                '$setCount',
                 style: const TextStyle(
                   fontSize: 22.0,
                   color: Colors.white
-                ),
+                ) ,
               ),
-            ),
-          ],
-        ),
+            )
+          ]
+        )
       ],
-    ),
+    )
   );
-} 
+}
 
-// This class simply decorates a row of widgets.
-class _TimerPickerItem extends StatelessWidget {
-  const _TimerPickerItem({required this.children});
+class _SetPickerItem extends StatelessWidget {
+  const _SetPickerItem({required this.children});
 
   final List<Widget> children;
 
@@ -114,3 +107,13 @@ class _TimerPickerItem extends StatelessWidget {
     );
   }
 }
+
+//   @override 
+//   Widget build(BuildContext context) => CupertinoTextField(
+//     keyboardType: TextInputType.number,
+//     style: TextStyle(color: Colors.white),
+//     onSubmitted: (String value) {
+//       setRepCount(int.parse(value));
+//     }
+//   );
+// } 

--- a/lib/widgets/time_display.dart
+++ b/lib/widgets/time_display.dart
@@ -23,7 +23,7 @@ class TimeDisplay extends StatelessWidget {
     children: [
       CircularProgressIndicator(
         value: timerSettings.getTimeRemainingPercentage(),
-        valueColor: AlwaysStoppedAnimation(Colors.white),
+        valueColor: timerSettings.getIsRepCycle() ? AlwaysStoppedAnimation(Colors.white) : AlwaysStoppedAnimation(Colors.red),
         backgroundColor: Colors.greenAccent,
         strokeWidth: 12,
       ),


### PR DESCRIPTION
Fixed timing bugs 
- Timer will now end on 0. Pausing and starting different sets doesn't increase speed of timer

smoother progress bar
- decreased the timer increment to 100 milliseconds so the progress bar animation will rerender 10x per second